### PR TITLE
Add redux devtools. Fix bug in search rerenders from old event listener.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "react-router-dom": "5.1.2",
     "react-scripts": "3.3.0",
     "redux": "^4.0.5",
+    "redux-devtools-extension": "^2.13.8",
     "redux-thunk": "^2.3.0"
   },
   "scripts": {

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -160,6 +160,10 @@ class Results extends React.PureComponent {
     document.addEventListener('keydown', this.onKeyDown);
   }
 
+  componentWillUnmount() {
+      document.removeEventListener('keydown', this.onKeyDown);
+  }
+
   onKeyDown = (eventObject) => {
     if (this.props.search.results.length) {
       if (this.UP_KEYS.includes(eventObject.which)) {

--- a/src/store.js
+++ b/src/store.js
@@ -21,7 +21,8 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import reducers from './reducers/reducers';
+import { composeWithDevTools } from 'redux-devtools-extension';
 
-const store = createStore(reducers, applyMiddleware(thunk));
+const store = createStore(reducers, composeWithDevTools(applyMiddleware(thunk)));
 
 export default store;


### PR DESCRIPTION
Add redux devtools (in store.js).

Remove search keydown event listener on unmount. This fixes a bug when re-rendering search (returning from About for example) due to persistence of old event listener.